### PR TITLE
improve PropertyViewCollection

### DIFF
--- a/src/Kapok.Core/Entity/Model/LookupDefinition.cs
+++ b/src/Kapok.Core/Entity/Model/LookupDefinition.cs
@@ -15,7 +15,7 @@ public interface ILookupDefinition
     /// The second <b><c>IDataDomainScope</c></b> parameter holds a data domain scope created for this call which
     /// can be used to access entity lists of the data domain. 
     /// </summary>
-    Func<object?, IDataDomainScope, IEnumerable<object>> EntriesFunc { get; set; }
+    Func<object?, IDataDomainScope, IQueryable<object>> EntriesFunc { get; set; }
 
     /// <summary>
     /// The field selector returning the property value to be written to the property.
@@ -47,7 +47,7 @@ public interface ILookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILook
     /// The second <b><c>IDataDomainScope</c></b> parameter holds a data domain scope created for this call which
     /// can be used to access entity lists of the data domain. 
     /// </summary>
-    new Func<TBaseEntry?, IDataDomainScope, IEnumerable<TLookupEntry>> EntriesFunc { get; set; }
+    new Func<TBaseEntry?, IDataDomainScope, IQueryable<TLookupEntry>> EntriesFunc { get; set; }
     
     /// <summary>
     /// The field selector returning the property value to be written to the property.
@@ -89,13 +89,13 @@ public class LookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDef
 
     public bool EntriesFuncDependentOnEntry { get; }
 
-    public Func<TBaseEntry?, IDataDomainScope, IEnumerable<TLookupEntry>> EntriesFunc { get; set; }
+    public Func<TBaseEntry?, IDataDomainScope, IQueryable<TLookupEntry>> EntriesFunc { get; set; }
 
     public Expression<Func<TLookupEntry, TFieldType>>? FieldSelectorFunc { get; set; }
 
     #region ILookupDefinition
         
-    Func<object?, IDataDomainScope, IEnumerable<object>> ILookupDefinition.EntriesFunc
+    Func<object?, IDataDomainScope, IQueryable<object>> ILookupDefinition.EntriesFunc
     {
         get
         {

--- a/src/Kapok.Core/Entity/Model/LookupDefinition.cs
+++ b/src/Kapok.Core/Entity/Model/LookupDefinition.cs
@@ -3,20 +3,58 @@ using Kapok.Data;
 
 namespace Kapok.Entity.Model;
 
+/// <summary>
+/// Represents a definition what possible items to show for a property.
+/// </summary>
 public interface ILookupDefinition
 {
-    Func<object, IDataDomainScope, IQueryable<object>> EntriesFunc { get; set; }
+    /// <summary>
+    /// A function returning the list of possible items in the combobox dropdown.
+    ///
+    /// The first <b><c>object?</c></b> parameter of the function represents the current item if set. This is only passed when <see cref="EntriesFuncDependentOnEntry"/> is <c>true</c>.
+    /// The second <b><c>IDataDomainScope</c></b> parameter holds a data domain scope created for this call which
+    /// can be used to access entity lists of the data domain. 
+    /// </summary>
+    Func<object?, IDataDomainScope, IEnumerable<object>> EntriesFunc { get; set; }
+
+    /// <summary>
+    /// The field selector returning the property value to be written to the property.
+    ///
+    /// The first <b><c>object</c></b> parameter represents the entity retrieved while iterating through <see cref="EntriesFunc"/>.
+    /// </summary>
     Expression<Func<object, object>>? FieldSelectorFunc { get; set; }
+    
+    /// <summary>
+    /// If the lookup is dynamic and depends on properties of the current item.
+    /// </summary>
     bool EntriesFuncDependentOnEntry { get; }
 }
 
+/// <summary>
+/// Represents a definition what possible items to show for a property.
+/// </summary>
+/// <typeparam name="TBaseEntry">entity type for which the property lookup is performed</typeparam>
+/// <typeparam name="TLookupEntry">lookup type</typeparam>
+/// <typeparam name="TFieldType">type of the returned value. Should match the type of the property the lookup is performed for</typeparam>
 public interface ILookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDefinition
     where TBaseEntry : class
     where TLookupEntry : class
 {
-    new Func<TBaseEntry, IDataDomainScope, IQueryable<TLookupEntry>> EntriesFunc { get; set; }
+    /// <summary>
+    /// A function returning the list of possible items in the combobox dropdown.
+    ///
+    /// The first <b><c>TBaseEntry</c></b> parameter of the function represents the current item if set. This is only passed when <see cref="ILookupDefinition.EntriesFuncDependentOnEntry"/> is <c>true</c>.
+    /// The second <b><c>IDataDomainScope</c></b> parameter holds a data domain scope created for this call which
+    /// can be used to access entity lists of the data domain. 
+    /// </summary>
+    new Func<TBaseEntry?, IDataDomainScope, IEnumerable<TLookupEntry>> EntriesFunc { get; set; }
+    
+    /// <summary>
+    /// The field selector returning the property value to be written to the property.
+    ///
+    /// The first <b><c>TLookupEntry</c></b> parameter represents the entity retrieved while iterating through <see cref="EntriesFunc"/>.
+    /// </summary>
     new Expression<Func<TLookupEntry, TFieldType>>? FieldSelectorFunc { get; set; }
-    new bool EntriesFuncDependentOnEntry { get; }
 }
 
 public class LookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDefinition<TBaseEntry, TLookupEntry, TFieldType>
@@ -29,7 +67,7 @@ public class LookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDef
         EntriesFuncDependentOnEntry = false;
     }
 
-    public LookupDefinition(Func<TBaseEntry, IDataDomainScope, IQueryable<TLookupEntry>> lookupEntriesFunc)
+    public LookupDefinition(Func<TBaseEntry?, IDataDomainScope, IQueryable<TLookupEntry>> lookupEntriesFunc)
     {
         EntriesFunc = lookupEntriesFunc;
         EntriesFuncDependentOnEntry = true;
@@ -42,7 +80,7 @@ public class LookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDef
         FieldSelectorFunc = fieldSelector;
     }
 
-    public LookupDefinition(Func<TBaseEntry, IDataDomainScope, IQueryable<TLookupEntry>> lookupEntriesFunc, Expression<Func<TLookupEntry, TFieldType>> fieldSelector)
+    public LookupDefinition(Func<TBaseEntry?, IDataDomainScope, IQueryable<TLookupEntry>> lookupEntriesFunc, Expression<Func<TLookupEntry, TFieldType>> fieldSelector)
     {
         EntriesFunc = lookupEntriesFunc;
         EntriesFuncDependentOnEntry = true;
@@ -51,17 +89,17 @@ public class LookupDefinition<TBaseEntry, TLookupEntry, TFieldType> : ILookupDef
 
     public bool EntriesFuncDependentOnEntry { get; }
 
-    public Func<TBaseEntry, IDataDomainScope, IQueryable<TLookupEntry>> EntriesFunc { get; set; }
+    public Func<TBaseEntry?, IDataDomainScope, IEnumerable<TLookupEntry>> EntriesFunc { get; set; }
 
     public Expression<Func<TLookupEntry, TFieldType>>? FieldSelectorFunc { get; set; }
 
     #region ILookupDefinition
         
-    Func<object, IDataDomainScope, IQueryable<object>> ILookupDefinition.EntriesFunc
+    Func<object?, IDataDomainScope, IEnumerable<object>> ILookupDefinition.EntriesFunc
     {
         get
         {
-            return (entry, dataDomainScope) => EntriesFunc.Invoke((TBaseEntry)entry, dataDomainScope);
+            return (entry, dataDomainScope) => EntriesFunc.Invoke((TBaseEntry?)entry, dataDomainScope);
         }
         set
         {

--- a/src/Kapok.View.UnitTest/UnitTestViewDomain.cs
+++ b/src/Kapok.View.UnitTest/UnitTestViewDomain.cs
@@ -23,7 +23,7 @@ public class UnitTestViewDomain : ViewDomain
     }
 
     public override IPropertyLookupView CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain,
-        IDataSetView? dataSet)
+        Func<object?>? currentSelector = null)
     {
         throw new NotImplementedException();
     }

--- a/src/Kapok.View/Contracts/IPropertyLookupView.cs
+++ b/src/Kapok.View/Contracts/IPropertyLookupView.cs
@@ -2,9 +2,21 @@
 
 namespace Kapok.View;
 
+/// <summary>
+/// A property lookup view holds the information what possible options to show in a UI combobox.
+/// </summary>
 public interface IPropertyLookupView
 {
+    /// <summary>
+    /// Holds the lookup definition.
+    /// </summary>
     ILookupDefinition LookupDefinition { get; }
 
+    /// <summary>
+    /// Tell to refresh the list of possible options in the combobox menu.
+    ///
+    /// This is e.g. called when possible options depend on a property of the current row and
+    /// the current row changed.
+    /// </summary>
     void Refresh();
 }

--- a/src/Kapok.View/Contracts/IViewDomain.cs
+++ b/src/Kapok.View/Contracts/IViewDomain.cs
@@ -31,6 +31,8 @@ public interface IViewDomain
     IQueryableView<TEntity> CreateQueryableView<TEntity>(IQueryable<TEntity> queryable)
         where TEntity : class;
 
+    IPropertyLookupView? CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain, Func<object?>? currentSelector = null);
+    [Obsolete("Please use CreatePropertyLookupView(ILookupDefinition, IDataDomain, Func<object?>?) instead")]
     IPropertyLookupView? CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain, IDataSetView? dataSet = null);
     IDataSetView<TEntry> CreateDataSetView<TEntry>(IDataDomainScope dataDomainScope, IDao<TEntry>? dao = null)
         where TEntry : class, new();

--- a/src/Kapok.View/ViewDomain.cs
+++ b/src/Kapok.View/ViewDomain.cs
@@ -207,7 +207,18 @@ public abstract class ViewDomain : IViewDomain
     public abstract IQueryableView<TEntity> CreateQueryableView<TEntity>(IQueryable<TEntity> queryable)
         where TEntity : class;
 
-    public abstract IPropertyLookupView CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain, IDataSetView? dataSet);
+    public abstract IPropertyLookupView CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain, Func<object?>? currentSelector = null);
+
+    IPropertyLookupView IViewDomain.CreatePropertyLookupView(ILookupDefinition lookupDefinition, IDataDomain dataDomain,
+        IDataSetView? dataSet)
+    {
+        if (dataSet == null)
+        {
+            return CreatePropertyLookupView(lookupDefinition, dataDomain, null);
+        }
+
+        return CreatePropertyLookupView(lookupDefinition, dataDomain, () => dataSet.Current);
+    }
 
     public IDataPage ConstructEntityDefaultPage(Type entityType, IDataDomainScope? dataDomainScope = null)
     {
@@ -273,10 +284,7 @@ public abstract class ViewDomain : IViewDomain
     {
         var tuple = (destinationType, menuName ?? UIMenu.BaseMenuName);
 
-        List<(string?, UIMenuItem)> l1;
-        if (DynamicMenuItems.ContainsKey(tuple))
-            l1 = DynamicMenuItems[tuple];
-        else
+        if (!DynamicMenuItems.TryGetValue(tuple, out List<(string?, UIMenuItem)>? l1))
         {
             l1 = new List<(string?, UIMenuItem)>();
             DynamicMenuItems.Add(tuple, l1);


### PR DESCRIPTION
simplifying PropertyViewCollection by adding a new constructor with `currentSelector` returning the current item related to the PropertyViewCollection